### PR TITLE
Update dependency 'ua-parser'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/statsig-io/ip3country-go v0.2.0
-	github.com/ua-parser/uap-go v0.0.0-20210121150957-347a3497cc39
+	github.com/ua-parser/uap-go v0.0.0-20211112212520-00c877edfe0f
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,9 @@
 github.com/statsig-io/ip3country-go v0.2.0 h1:4z4ovVCx7GnQAKJC753bjcOgxLQJFsrDdcCKda4I2U8=
 github.com/statsig-io/ip3country-go v0.2.0/go.mod h1:PKuA/VSpe4puBXw3BNGAHyP8IOZOiXAh/xIz+iYYoMQ=
-github.com/ua-parser/uap-go v0.0.0-20210121150957-347a3497cc39 h1:kYO0jPTV2Co2s3unqZl3GgB+T27G+ZRRU2/iXEX+TK4=
-github.com/ua-parser/uap-go v0.0.0-20210121150957-347a3497cc39/go.mod h1:OBcG9bn7sHtXgarhUEb3OfCnNsgtGnkVf41ilSZ3K3E=
+github.com/ua-parser/uap-go v0.0.0-20211112212520-00c877edfe0f h1:A+MmlgpvrHLeUP8dkBVn4Pnf5Bp5Yk2OALm7SEJLLE8=
+github.com/ua-parser/uap-go v0.0.0-20211112212520-00c877edfe0f/go.mod h1:OBcG9bn7sHtXgarhUEb3OfCnNsgtGnkVf41ilSZ3K3E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
The current version of 'ua-parser' is vulnerable to Regular Expression Denial of Service attacks. This vulnerability was fixed as part of https://github.com/ua-parser/uap-go/pull/73 (commit: https://github.com/ua-parser/uap-go/commit/3b2ceb1c75a3cf8f5e560d46236229a70e98566e).

This PR updates the 'ua-parser' dependency to the latest version, which includes the vulnerability fix 🙂 

```
go get -u github.com/ua-parser/uap-go
go mod tidy
```