### PR TITLE
don't lock if already locked

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -75,7 +75,7 @@ func (l *logger) logInternal(evt interface{}) {
 
 	l.events = append(l.events, evt)
 	if len(l.events) >= maxEvents {
-		l.flush(false)
+		l.flushInternal(false)
 	}
 }
 
@@ -121,6 +121,11 @@ func (l *logger) flush(closing bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	l.flushInternal(closing)
+}
+
+
+func (l *logger) flushInternal(closing bool) {
 	if closing {
 		l.tick.Stop()
 	}


### PR DESCRIPTION
the logInternal method calls mu.Lock() twice, resulting in a deadlock. This removes one of the locks so that logging can progress. Tested by running 100 go routines each doing 10,000 gate checks and doing that 100 times in succession. 