### PR TITLE
fix data race with multiple map writers

### DIFF
--- a/client.go
+++ b/client.go
@@ -211,13 +211,11 @@ func fetchConfig(user User, configName string, t *transport) configResponse {
 }
 
 func normalizeUser(user User, options Options) User {
-	var env map[string]string
-	if len(options.Environment.Params) > 0 {
-		env = options.Environment.Params
-	} else {
-		env = make(map[string]string)
+	env := make(map[string]string)
+	// Copy to avoid data race. We modify the map below.
+	for k, v := range options.Environment.Params {
+		env[k] = v
 	}
-
 	if options.Environment.Tier != "" {
 		env["tier"] = options.Environment.Tier
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,34 @@
+package statsig
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNormalizeUserDataRace(t *testing.T) {
+	const (
+		goroutines = 10
+		duration   = time.Second
+	)
+	options := Options{
+		Environment: Environment{
+			Params: map[string]string{
+				"foo": "bar",
+			},
+			Tier: "awesome",
+		},
+	}
+	start := time.Now()
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for time.Since(start) < duration {
+				normalizeUser(User{UserID: "cruise-llc"}, options)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
When the client is initialized with params, the normalizeUser function will concurrently write the params map. This causes the go runtime to panic saying "fatal error: concurrent map writes".

This change fixes the data race by always copying the map when normalizing the user.