### PR TITLE
Add a method to figure out whether initialization has happened or not

### DIFF
--- a/statsig.go
+++ b/statsig.go
@@ -11,6 +11,11 @@ const DefaultEndpoint = "https://statsigapi.net/v1"
 
 var instance *Client
 
+// IsInitialized returns whether the global Statsig instance has already been initialized or not
+func IsInitialized() bool {
+	return instance != nil
+}
+
 // Initializes the global Statsig instance with the given sdkKey
 func Initialize(sdkKey string) {
 	if IsInitialized() {


### PR DESCRIPTION
Sometimes it is unclear whether the global statsig instance has already been initialized, so it would be good to be able to check for that. This adds a method to allow that check.