### PR TITLE
Fixing Go code style issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![tests](https://github.com/statsig-io/go-sdk/actions/workflows/test.yml/badge.svg)](https://github.com/statsig-io/go-sdk/actions/workflows/test.yml)
 
-The Statsig Go SDK for multi-user, server side environments. If you need a SDK for another language or single user client environment, check out our [other SDKs](https://docs.statsig.com/#sdks).
+The Statsig Go SDK for multi-user, server side environments. If you need an SDK for another language or single user client environment, check out our [other SDKs](https://docs.statsig.com/#sdks).
 
 Statsig helps you move faster with Feature Gates (Feature Flags) and Dynamic Configs. It also allows you to run A/B tests to validate your new features and understand their impact on your KPIs. If you're new to Statsig, create an account at [statsig.com](https://www.statsig.com).
 
@@ -12,10 +12,10 @@ Check out our [SDK docs](https://docs.statsig.com/server/golangSDK) to get start
 
 ## Testing
 
-Each server SDK is tested at multiple levels - from unit to integration and e2e tests. Our internal e2e test harness runs daily against each server SDK, while unit and integration tests can be seen in the respective github repos of each SDK. The `statsig_test.go` runs a validation test on local rule/condition evaluation for this SDK against the results in the statsig backend.
+Each server SDK is tested at multiple levels - from unit to integration and e2e tests. Our internal e2e test harness runs daily against each server SDK, while unit and integration tests can be seen in the respective GitHub repos of each SDK. The `statsig_test.go` runs a validation test on local rule/condition evaluation for this SDK against the results in the statsig backend.
 
 ## Guidelines
 
-- Pull requests are welcome! 
+- Pull requests are welcome!
 - If you encounter bugs, feel free to [file an issue](https://github.com/statsig-io/go-sdk/issues).
 - For integration questions/help, [join our slack community](https://join.slack.com/t/statsigcommunity/shared_invite/zt-pbp005hg-VFQOutZhMw5Vu9eWvCro9g).

--- a/client_initialize_response_test.go
+++ b/client_initialize_response_test.go
@@ -63,7 +63,7 @@ func TestInitializeResponseConsistency(t *testing.T) {
 			InitializeWithOptions(secret, &Options{
 				API:                  api,
 				OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-				StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+				StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 			})
 			defer ShutdownAndDangerouslyClearInstance()
 

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -56,7 +56,7 @@ func TestCallingAPIsConcurrently(t *testing.T) {
 			Tier: "awesome_land",
 		},
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	}
 
 	InitializeWithOptions("secret-key", options)

--- a/data_adapter_example.go
+++ b/data_adapter_example.go
@@ -26,17 +26,17 @@ func (d *dataAdapterExample) Initialize() {}
 
 func (d *dataAdapterExample) Shutdown() {}
 
-func (d *dataAdapterExample) ShouldBeUsedForQueryingUpdates(key string) bool {
+func (d *dataAdapterExample) ShouldBeUsedForQueryingUpdates(string) bool {
 	return false
 }
 
 type brokenDataAdapterExample struct{}
 
-func (d brokenDataAdapterExample) Get(key string) string {
+func (d brokenDataAdapterExample) Get(string) string {
 	panic(errors.New("invalid get function"))
 }
 
-func (d brokenDataAdapterExample) Set(key string, value string) {
+func (d brokenDataAdapterExample) Set(string, string) {
 	panic(errors.New("invalid set function"))
 }
 
@@ -44,7 +44,7 @@ func (d brokenDataAdapterExample) Initialize() {}
 
 func (d brokenDataAdapterExample) Shutdown() {}
 
-func (d brokenDataAdapterExample) ShouldBeUsedForQueryingUpdates(key string) bool {
+func (d brokenDataAdapterExample) ShouldBeUsedForQueryingUpdates(string) bool {
 	return false
 }
 
@@ -69,7 +69,7 @@ func (d *dataAdapterWithPollingExample) Initialize() {}
 
 func (d *dataAdapterWithPollingExample) Shutdown() {}
 
-func (d *dataAdapterWithPollingExample) ShouldBeUsedForQueryingUpdates(key string) bool {
+func (d *dataAdapterWithPollingExample) ShouldBeUsedForQueryingUpdates(string) bool {
 	return true
 }
 func (d *dataAdapterWithPollingExample) clearStore(key string) {

--- a/data_adapter_interface.go
+++ b/data_adapter_interface.go
@@ -1,37 +1,27 @@
 package statsig
 
-const CONFIG_SPECS_KEY = "statsig.cache"
-const ID_LISTS_KEY = "statsig.id_lists"
+const (
+	configSpecsKey = "statsig.cache"
+	idListsKey     = "statsig.id_lists"
+)
 
-/**
- * An adapter for implementing custom storage of config specs.
- * Can be used to bootstrap Statsig (priority over bootstrapValues if both provided)
- * Also useful for backing up cached data
- */
+// IDataAdapter is an adapter for implementing custom storage of config specs.
+// Can be used to bootstrap Statsig (priority over bootstrapValues if both provided)
+// Also useful for backing up cached data
 type IDataAdapter interface {
-	/**
-	 * Returns the data stored for a specific key
-	 */
+	// Get returns the data stored for a specific key
 	Get(key string) string
 
-	/**
-	 * Updates data stored for each key
-	 */
+	// Set updates data stored for each key
 	Set(key string, value string)
 
-	/**
-	 * Startup tasks to run before any get/set calls can be made
-	 */
+	// Initialize starts up tasks to run before any get/set calls can be made
 	Initialize()
 
-	/**
-	 * Cleanup tasks to run when statsig is shutdown
-	 */
+	// Shutdown cleans up tasks to run when statsig is shutdown
 	Shutdown()
 
-	/**
-		 * Determines whether the SDK should poll for updates from
-	   * the data adapter (instead of Statsig network) for the given key
-	*/
+	// ShouldBeUsedForQueryingUpdates determines whether the SDK should poll for updates
+	// from the data adapter (instead of Statsig network) for the given key
 	ShouldBeUsedForQueryingUpdates(key string) bool
 }

--- a/diagnostics.go
+++ b/diagnostics.go
@@ -7,17 +7,16 @@ import (
 	"time"
 )
 
+type DiagnosticsAction string
+type DiagnosticsStep string
+type DiagnosticsKey string
 type DiagnosticsContext string
 
 const (
 	InitializeContext DiagnosticsContext = "initialize"
 	ConfigSyncContext DiagnosticsContext = "config_sync"
 	ApiCallContext    DiagnosticsContext = "api_call"
-)
 
-type DiagnosticsKey string
-
-const (
 	DownloadConfigSpecsKey  DiagnosticsKey = "download_config_specs"
 	BootstrapKey            DiagnosticsKey = "bootstrap"
 	GetIDListSourcesKey     DiagnosticsKey = "get_id_list_sources"
@@ -29,24 +28,16 @@ const (
 	CheckGateApiKey         DiagnosticsKey = "check_gate"
 	GetConfigApiKey         DiagnosticsKey = "get_config"
 	GetLayerApiKey          DiagnosticsKey = "get_layer"
-)
 
-type DiagnosticsStep string
-
-const (
 	NetworkRequestStep DiagnosticsStep = "network_request"
 	FetchStep          DiagnosticsStep = "fetch"
 	ProcessStep        DiagnosticsStep = "process"
-)
 
-type DiagnosticsAction string
-
-const (
 	StartAction DiagnosticsAction = "start"
 	EndAction   DiagnosticsAction = "end"
-)
 
-const MaxMarkerSize = 50
+	MaxMarkerSize = 50
+)
 
 type diagnosticsBase struct {
 	context       DiagnosticsContext
@@ -142,9 +133,9 @@ func (d *diagnosticsBase) updateSamplingRates(samplingRates map[string]int) {
 	d.samplingRates = samplingRates
 }
 
-func sample(rate_over_ten_thousand int) bool {
+func sample(rateOverTenThousand int) bool {
 	rand.Seed(time.Now().UnixNano())
-	return int(math.Floor(rand.Float64()*10_000)) < rate_over_ten_thousand
+	return int(math.Floor(rand.Float64()*10_000)) < rateOverTenThousand
 }
 
 func (d *diagnosticsBase) clearMarkers() {

--- a/error_boundary.go
+++ b/error_boundary.go
@@ -31,13 +31,15 @@ type logExceptionResponse struct {
 	Success bool
 }
 
-var ErrorBoundaryAPI = "https://statsigapi.net/v1"
-var ErrorBoundaryEndpoint = "/sdk_exception"
+var (
+	ErrorBoundaryAPI      = "https://statsigapi.net/v1"
+	ErrorBoundaryEndpoint = "/sdk_exception"
+)
 
 const (
-	InvalidSDKKeyError  string = "Must provide a valid SDK key."
-	EmptyUserError      string = "A non-empty StatsigUser.UserID or StatsigUser.CustomIDs is required. See https://docs.statsig.com/messages/serverRequiredUserID"
-	EventBatchSizeError string = "The max number of events supported in one batch is 500. Please reduce the slice size and try again."
+	InvalidSDKKeyError  string = "must provide a valid SDK key"
+	EmptyUserError      string = "a non-empty StatsigUser.UserID or StatsigUser.CustomIDs is required. See https://docs.statsig.com/messages/serverRequiredUserID"
+	EventBatchSizeError string = "the max number of events supported in one batch is 500. Please reduce the slice size and try again"
 )
 
 func newErrorBoundary(sdkKey string, options *Options, diagnostics *diagnostics) *errorBoundary {

--- a/error_boundary_test.go
+++ b/error_boundary_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func mock_server(t *testing.T, expectedError error, hit *bool) *httptest.Server {
+func mockServer(t *testing.T, expectedError error, hit *bool) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if strings.Contains(req.URL.Path, "/download_config_specs") {
 			res.WriteHeader(500)
@@ -34,7 +34,7 @@ func mock_server(t *testing.T, expectedError error, hit *bool) *httptest.Server 
 func TestLogException(t *testing.T) {
 	err := errors.New("test error boundary log exception")
 	hit := false
-	testServer := mock_server(t, err, &hit)
+	testServer := mockServer(t, err, &hit)
 	defer testServer.Close()
 	opt := &Options{
 		API: testServer.URL,
@@ -49,12 +49,12 @@ func TestLogException(t *testing.T) {
 
 func TestDCSError(t *testing.T) {
 	hit := false
-	testServer := mock_server(t, nil, &hit)
+	testServer := mockServer(t, nil, &hit)
 	defer testServer.Close()
 	opt := &Options{
 		API:                  testServer.URL,
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	}
 	InitializeWithOptions("secret-key", opt)
 	defer ShutdownAndDangerouslyClearInstance()
@@ -66,7 +66,7 @@ func TestDCSError(t *testing.T) {
 func TestRepeatedError(t *testing.T) {
 	err := errors.New("common error")
 	hit := false
-	testServer := mock_server(t, err, &hit)
+	testServer := mockServer(t, err, &hit)
 	defer testServer.Close()
 	opt := &Options{
 		API: testServer.URL,

--- a/evaluation_details_test.go
+++ b/evaluation_details_test.go
@@ -55,7 +55,7 @@ func TestEvaluationDetails(t *testing.T) {
 			API:                  getTestServer(true).URL,
 			Environment:          Environment{Tier: "test"},
 			OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-			StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+			StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 			EvaluationCallbacks:  evaluationCallbacks,
 		}
 		user = User{UserID: "some_user_id"}

--- a/evaluator.go
+++ b/evaluator.go
@@ -31,8 +31,8 @@ type evalResult struct {
 	IsExperimentGroup             *bool
 }
 
-func newEvalResultFromUserPersistedValues(configName string, persitedValues UserPersistedValues) *evalResult {
-	if stickyValues, ok := persitedValues[configName]; ok {
+func newEvalResultFromUserPersistedValues(configName string, persistedValues UserPersistedValues) *evalResult {
+	if stickyValues, ok := persistedValues[configName]; ok {
 		newEvalResult := newEvalResultFromMap(stickyValues)
 		return newEvalResult
 	}
@@ -44,8 +44,8 @@ func newEvalResultFromMap(evalMap map[string]interface{}) *evalResult {
 	var secondaryExposures []map[string]string
 	evaluationDetails := newEvaluationDetails(
 		reasonPersisted,
-		safeParseJSONint64(evalMap["configSyncTime"]),
-		safeParseJSONint64(evalMap["initTime"]),
+		safeParseJSONInt64(evalMap["configSyncTime"]),
+		safeParseJSONInt64(evalMap["initTime"]),
 	)
 	configValue := evalMap["ConfigValue"].(map[string]interface{})
 	if secondaryExposures, ok = evalMap["SecondaryExposures"].([]map[string]string); !ok {
@@ -246,21 +246,21 @@ func (e *evaluator) getLayerOverride(name string) (map[string]interface{}, bool)
 	return layer, ok
 }
 
-// Override the value of a Feature Gate for the given user
+// OverrideGate overrides the value of a Feature Gate for the given user
 func (e *evaluator) OverrideGate(gate string, val bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.gateOverrides[gate] = val
 }
 
-// Override the DynamicConfig value for the given user
+// OverrideConfig overrides the DynamicConfig value for the given user
 func (e *evaluator) OverrideConfig(config string, val map[string]interface{}) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.configOverrides[config] = val
 }
 
-// Override the Layer value for the given user
+// OverrideLayer overrides the Layer value for the given user
 func (e *evaluator) OverrideLayer(layer string, val map[string]interface{}) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -820,11 +820,11 @@ func arrayAny(arr interface{}, val interface{}, fun func(x, y interface{}) bool)
 func getTime(a interface{}) time.Time {
 	switch v := a.(type) {
 	case float64, int64, int32, int:
-		t_sec := time.Unix(getUnixTimestamp(v), 0)
-		if t_sec.Year() > time.Now().Year()+100 {
+		tSec := time.Unix(getUnixTimestamp(v), 0)
+		if tSec.Year() > time.Now().Year()+100 {
 			return time.Unix(getUnixTimestamp(v)/1000, 0)
 		}
-		return t_sec
+		return tSec
 	case string:
 		t, err := time.Parse(time.RFC3339, v)
 		if err == nil {
@@ -834,11 +834,11 @@ func getTime(a interface{}) time.Time {
 		if err != nil {
 			return time.Time{}
 		}
-		t_sec := time.Unix(getUnixTimestamp(vInt), 0)
-		if t_sec.Year() > time.Now().Year()+100 {
+		tSec := time.Unix(getUnixTimestamp(vInt), 0)
+		if tSec.Year() > time.Now().Year()+100 {
 			return time.Unix(getUnixTimestamp(vInt)/1000, 0)
 		}
-		return t_sec
+		return tSec
 	}
 	return time.Time{}
 }

--- a/exposure_logging_test.go
+++ b/exposure_logging_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestExposureLogging(t *testing.T) {
-	events := []Event{}
+	var events []Event
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusOK)
@@ -37,7 +37,7 @@ func TestExposureLogging(t *testing.T) {
 		API:                  testServer.URL,
 		Environment:          Environment{Tier: "test"},
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	}
 
 	user := User{UserID: "some_user_id", Email: "someuser@statsig.com"}

--- a/global_state.go
+++ b/global_state.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// Using global state variables directly will lead to race conditions
+// GlobalState direct usage will lead to race conditions
 // Instead, define an accessor below using the Mutex lock
 type GlobalState struct {
 	logger    *OutputLogger

--- a/init_timeout_test.go
+++ b/init_timeout_test.go
@@ -24,7 +24,7 @@ func TestInitTimeout(t *testing.T) {
 		options := &Options{
 			API:                  testServer.URL,
 			OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-			StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+			StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 		}
 		start := time.Now()
 		InitializeWithOptions("secret-key", options)
@@ -41,12 +41,12 @@ func TestInitTimeout(t *testing.T) {
 		ShutdownAndDangerouslyClearInstance()
 	})
 
-	t.Run("Initalize finish before timeout", func(t *testing.T) {
+	t.Run("Initialize finish before timeout", func(t *testing.T) {
 		options := &Options{
 			API:                  testServer.URL,
 			InitTimeout:          5 * time.Second,
 			OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-			StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+			StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 		}
 		start := time.Now()
 		InitializeWithOptions("secret-key", options)
@@ -71,7 +71,7 @@ func TestInitTimeout(t *testing.T) {
 			API:                  testServer.URL,
 			InitTimeout:          100 * time.Millisecond,
 			OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-			StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+			StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 		}
 		start := time.Now()
 		InitializeWithOptions("secret-key", options)

--- a/layer_exposure_test.go
+++ b/layer_exposure_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLayerExposure(t *testing.T) {
-	events := []Event{}
+	var events []Event
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusOK)
@@ -37,7 +37,7 @@ func TestLayerExposure(t *testing.T) {
 		API:                  testServer.URL,
 		Environment:          Environment{Tier: "test"},
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	}
 
 	user := User{UserID: "some_user_id"}

--- a/logger.go
+++ b/logger.go
@@ -13,6 +13,8 @@ const (
 	GateExposureEventName   ExposureEventName = "statsig::gate_exposure"
 	ConfigExposureEventName ExposureEventName = "statsig::config_exposure"
 	LayerExposureEventName  ExposureEventName = "statsig::layer_exposure"
+
+	diagnosticsEventName = "statsig::diagnostics"
 )
 
 type ExposureEvent struct {
@@ -23,8 +25,6 @@ type ExposureEvent struct {
 	SecondaryExposures []map[string]string `json:"secondaryExposures"`
 	Time               int64               `json:"time"`
 }
-
-const diagnosticsEventName = "statsig::diagnostics"
 
 type diagnosticsEvent struct {
 	EventName string                 `json:"eventName"`

--- a/statsig.go
+++ b/statsig.go
@@ -9,7 +9,7 @@ import (
 
 var instance *Client
 
-// Initializes the global Statsig instance with the given sdkKey
+// Initialize initializes the global Statsig instance with the given sdkKey
 func Initialize(sdkKey string) {
 	InitializeGlobalOutputLogger(OutputLoggerOptions{})
 	InitializeGlobalSessionID()
@@ -21,7 +21,7 @@ func Initialize(sdkKey string) {
 	instance = NewClient(sdkKey)
 }
 
-// Advanced options for configuring the Statsig SDK
+// Options are an advanced options for configuring the Statsig SDK
 type Options struct {
 	API                   string      `json:"api"`
 	Environment           Environment `json:"environment"`
@@ -62,6 +62,7 @@ type StatsigLoggerOptions struct {
 	DisableAllLogging      bool
 }
 
+// Environment is a struct that represents the environment option
 // See https://docs.statsig.com/guides/usingEnvironments
 type Environment struct {
 	Tier   string            `json:"tier"`
@@ -73,7 +74,7 @@ func IsInitialized() bool {
 	return instance != nil
 }
 
-// Initializes the global Statsig instance with the given sdkKey and options
+// InitializeWithOptions initializes the global Statsig instance with the given sdkKey and options
 func InitializeWithOptions(sdkKey string, options *Options) {
 	InitializeGlobalOutputLogger(options.OutputLoggerOptions)
 	InitializeGlobalSessionID()
@@ -101,7 +102,7 @@ func InitializeWithOptions(sdkKey string, options *Options) {
 	}
 }
 
-// Checks the value of a Feature Gate for the given user
+// CheckGate checks the value of a Feature Gate for the given user
 func CheckGate(user User, gate string) bool {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling CheckGate"))
@@ -109,7 +110,7 @@ func CheckGate(user User, gate string) bool {
 	return instance.CheckGate(user, gate)
 }
 
-// Checks the value of a Feature Gate for the given user without logging an exposure event
+// CheckGateWithExposureLoggingDisabled checks the value of a Feature Gate for the given user without logging an exposure event
 func CheckGateWithExposureLoggingDisabled(user User, gate string) bool {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling CheckGateWithExposureLoggingDisabled"))
@@ -117,7 +118,7 @@ func CheckGateWithExposureLoggingDisabled(user User, gate string) bool {
 	return instance.CheckGateWithExposureLoggingDisabled(user, gate)
 }
 
-// Get the Feature Gate for the given user
+// GetGate gets the Feature Gate for the given user
 func GetGate(user User, gate string) FeatureGate {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetGate"))
@@ -125,7 +126,7 @@ func GetGate(user User, gate string) FeatureGate {
 	return instance.GetGate(user, gate)
 }
 
-// Get the Feature Gate for the given user without logging an exposure event
+// GetGateWithExposureLoggingDisabled gets the Feature Gate for the given user without logging an exposure event
 func GetGateWithExposureLoggingDisabled(user User, gate string) FeatureGate {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetGateWithExposureLoggingDisabled"))
@@ -133,7 +134,7 @@ func GetGateWithExposureLoggingDisabled(user User, gate string) FeatureGate {
 	return instance.GetGateWithExposureLoggingDisabled(user, gate)
 }
 
-// Logs an exposure event for the gate
+// ManuallyLogGateExposure logs an exposure event for the gate
 func ManuallyLogGateExposure(user User, config string) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling ManuallyLogGateExposure"))
@@ -141,7 +142,7 @@ func ManuallyLogGateExposure(user User, config string) {
 	instance.ManuallyLogGateExposure(user, config)
 }
 
-// Gets the DynamicConfig value for the given user
+// GetConfig gets the DynamicConfig value for the given user
 func GetConfig(user User, config string) DynamicConfig {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetConfig"))
@@ -149,7 +150,7 @@ func GetConfig(user User, config string) DynamicConfig {
 	return instance.GetConfig(user, config)
 }
 
-// Gets the DynamicConfig value for the given user without logging an exposure event
+// GetConfigWithExposureLoggingDisabled gets the DynamicConfig value for the given user without logging an exposure event
 func GetConfigWithExposureLoggingDisabled(user User, config string) DynamicConfig {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetConfigWithExposureLoggingDisabled"))
@@ -157,7 +158,7 @@ func GetConfigWithExposureLoggingDisabled(user User, config string) DynamicConfi
 	return instance.GetConfigWithExposureLoggingDisabled(user, config)
 }
 
-// Logs an exposure event for the dynamic config
+// ManuallyLogConfigExposure logs an exposure event for the dynamic config
 func ManuallyLogConfigExposure(user User, config string) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling ManuallyLogConfigExposure"))
@@ -165,7 +166,7 @@ func ManuallyLogConfigExposure(user User, config string) {
 	instance.ManuallyLogConfigExposure(user, config)
 }
 
-// Override the value of a Feature Gate for the given user
+// OverrideGate overrides the value of a Feature Gate for the given user
 func OverrideGate(gate string, val bool) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling OverrideGate"))
@@ -173,7 +174,7 @@ func OverrideGate(gate string, val bool) {
 	instance.OverrideGate(gate, val)
 }
 
-// Override the DynamicConfig value for the given user
+// OverrideConfig overrides the DynamicConfig value for the given user
 func OverrideConfig(config string, val map[string]interface{}) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling OverrideConfig"))
@@ -181,7 +182,7 @@ func OverrideConfig(config string, val map[string]interface{}) {
 	instance.OverrideConfig(config, val)
 }
 
-// Override the Layer value for the given user
+// OverrideLayer overrides the Layer value for the given user
 func OverrideLayer(layer string, val map[string]interface{}) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling OverrideLayer"))
@@ -189,7 +190,7 @@ func OverrideLayer(layer string, val map[string]interface{}) {
 	instance.OverrideLayer(layer, val)
 }
 
-// Gets the DynamicConfig value of an Experiment for the given user
+// GetExperiment gets the DynamicConfig value of an Experiment for the given user
 func GetExperiment(user User, experiment string) DynamicConfig {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetExperiment"))
@@ -197,7 +198,7 @@ func GetExperiment(user User, experiment string) DynamicConfig {
 	return instance.GetExperiment(user, experiment)
 }
 
-// Gets the DynamicConfig value of an Experiment for the given user without logging an exposure event
+// GetExperimentWithExposureLoggingDisabled gets the DynamicConfig value of an Experiment for the given user without logging an exposure event
 func GetExperimentWithExposureLoggingDisabled(user User, experiment string) DynamicConfig {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetExperimentWithExposureLoggingDisabled"))
@@ -205,7 +206,7 @@ func GetExperimentWithExposureLoggingDisabled(user User, experiment string) Dyna
 	return instance.GetExperimentWithExposureLoggingDisabled(user, experiment)
 }
 
-// Gets the DynamicConfig value of an Experiment for the given user with configurable options
+// GetExperimentWithOptions gets the DynamicConfig value of an Experiment for the given user with configurable options
 func GetExperimentWithOptions(user User, experiment string, options *GetExperimentOptions) DynamicConfig {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetExperimentWithOptions"))
@@ -213,7 +214,7 @@ func GetExperimentWithOptions(user User, experiment string, options *GetExperime
 	return instance.GetExperimentWithOptions(user, experiment, options)
 }
 
-// Logs an exposure event for the experiment
+// ManuallyLogExperimentExposure logs an exposure event for the experiment
 func ManuallyLogExperimentExposure(user User, experiment string) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling ManuallyLogExperimentExposure"))
@@ -221,6 +222,7 @@ func ManuallyLogExperimentExposure(user User, experiment string) {
 	instance.ManuallyLogExperimentExposure(user, experiment)
 }
 
+// GetUserPersistedValues gets the PersistedValues for the given user
 func GetUserPersistedValues(user User, idType string) UserPersistedValues {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetUserPersistedValues"))
@@ -228,7 +230,7 @@ func GetUserPersistedValues(user User, idType string) UserPersistedValues {
 	return instance.GetUserPersistedValues(user, idType)
 }
 
-// Gets the Layer object for the given user
+// GetLayer gets the Layer object for the given user
 func GetLayer(user User, layer string) Layer {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetLayer"))
@@ -236,7 +238,7 @@ func GetLayer(user User, layer string) Layer {
 	return instance.GetLayer(user, layer)
 }
 
-// Gets the Layer object for the given user without logging an exposure event
+// GetLayerWithExposureLoggingDisabled gets the Layer object for the given user without logging an exposure event
 func GetLayerWithExposureLoggingDisabled(user User, layer string) Layer {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling GetLayerWithExposureLoggingDisabled"))
@@ -244,7 +246,7 @@ func GetLayerWithExposureLoggingDisabled(user User, layer string) Layer {
 	return instance.GetLayerWithExposureLoggingDisabled(user, layer)
 }
 
-// Logs an exposure event for the parameter in the given layer
+// ManuallyLogLayerParameterExposure logs an exposure event for the parameter in the given layer
 func ManuallyLogLayerParameterExposure(user User, layer string, parameter string) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling ManuallyLogLayerParameterExposure"))
@@ -252,7 +254,7 @@ func ManuallyLogLayerParameterExposure(user User, layer string, parameter string
 	instance.ManuallyLogLayerParameterExposure(user, layer, parameter)
 }
 
-// Logs an event to the Statsig console
+// LogEvent logs an event to the Statsig console
 func LogEvent(event Event) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling LogEvent"))
@@ -260,7 +262,7 @@ func LogEvent(event Event) {
 	instance.LogEvent(event)
 }
 
-// Logs a slice of events to Statsig server immediately
+// LogImmediate logs a slice of events to Statsig server immediately
 func LogImmediate(events []Event) (*http.Response, error) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling LogImmediate"))
@@ -282,7 +284,7 @@ func GetClientInitializeResponseForTargetApp(user User, clientKey string) Client
 	return instance.GetClientInitializeResponse(user, clientKey)
 }
 
-// Cleans up Statsig, persisting any Event Logs and cleanup processes
+// Shutdown cleans up Statsig, persisting any Event Logs and cleanup processes
 // Using any method is undefined after Shutdown() has been called
 func Shutdown() {
 	if !IsInitialized() {
@@ -291,7 +293,7 @@ func Shutdown() {
 	instance.Shutdown()
 }
 
-// For test only so we can clear the shared instance. Not thread safe.
+// ShutdownAndDangerouslyClearInstance is used for test only so we can clear the shared instance. Not thread safe.
 func ShutdownAndDangerouslyClearInstance() {
 	Shutdown()
 	instance = nil

--- a/statsig_metadata_test.go
+++ b/statsig_metadata_test.go
@@ -29,7 +29,7 @@ func TestStatsigMetadata(t *testing.T) {
 			}
 		}).URL,
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 		LoggingMaxBufferSize: 1,
 	})
 	if sessionID == "" {
@@ -47,7 +47,7 @@ func TestStatsigMetadata(t *testing.T) {
 			}
 		}).URL,
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	})
 	ShutdownAndDangerouslyClearInstance()
 }

--- a/statsig_test.go
+++ b/statsig_test.go
@@ -17,7 +17,7 @@ func TestBootstrap(t *testing.T) {
 	bytes, _ := os.ReadFile("download_config_specs.json")
 	InitializeWithOptions("secret-key", &Options{
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	})
 	if !IsInitialized() {
 		t.Errorf("expected statsig to be initialized")
@@ -30,7 +30,7 @@ func TestBootstrap(t *testing.T) {
 	opt := &Options{
 		BootstrapValues:      string(bytes[:]),
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	}
 	InitializeWithOptions("secret-key", opt)
 
@@ -60,7 +60,7 @@ func TestRulesUpdatedCallback(t *testing.T) {
 			}
 		},
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	}
 
 	InitializeWithOptions("secret-key", opt)
@@ -76,13 +76,13 @@ func TestRulesUpdatedCallback(t *testing.T) {
 	ShutdownAndDangerouslyClearInstance()
 
 	// Now use rules from the previous update callback to bootstrap, and validate values
-	opt_bootstrap := &Options{
+	optBootstrap := &Options{
 		BootstrapValues:      rules,
 		LocalMode:            true,
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	}
-	InitializeWithOptions("secret-key", opt_bootstrap)
+	InitializeWithOptions("secret-key", optBootstrap)
 
 	if !CheckGate(User{UserID: "123"}, "always_on_gate") {
 		t.Errorf("always_on_gate should return true bootstrap value is provided")
@@ -118,7 +118,7 @@ func TestLogImmediate(t *testing.T) {
 		API:                  testServer.URL,
 		Environment:          Environment{Tier: "test"},
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	}
 	InitializeWithOptions("secret-key", opt)
 	event := Event{EventName: "test_event", User: User{UserID: "123"}}

--- a/store_sync_failure_log_test.go
+++ b/store_sync_failure_log_test.go
@@ -24,23 +24,23 @@ func TestStoreSyncFailure(t *testing.T) {
 		Environment:          Environment{Tier: "test"},
 		ConfigSyncInterval:   100 * time.Millisecond,
 		OutputLoggerOptions:  getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions: getStatsigLoggerOptionsForTest(),
 	}
 
 	syncOutdatedMax = 200 * time.Millisecond
-	stderrLogs := swallow_stderr(func() {
+	stderrLogs := swallowStderr(func() {
 		InitializeWithOptions("secret-key", opt)
 	})
 	if stderrLogs == "" {
 		t.Error("Expected error message in stderr")
 	}
-	stderrLogs = swallow_stderr(func() {
+	stderrLogs = swallowStderr(func() {
 		time.Sleep(100 * time.Millisecond)
 	})
 	if stderrLogs != "" {
 		t.Error("Expected no output to stderr")
 	}
-	stderrLogs = swallow_stderr(func() {
+	stderrLogs = swallowStderr(func() {
 		time.Sleep(100 * time.Millisecond)
 	})
 	if stderrLogs == "" {

--- a/transport.go
+++ b/transport.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -56,13 +55,13 @@ type RequestOptions struct {
 	backoff time.Duration
 }
 
-func (opts *RequestOptions) fill_defaults() {
+func (opts *RequestOptions) fillDefaults() {
 	if opts.backoff == 0 {
 		opts.backoff = time.Second
 	}
 }
 
-func (transport *transport) download_config_specs(sinceTime int64, responseBody interface{}) (*http.Response, error) {
+func (transport *transport) downloadConfigSpecs(sinceTime int64, responseBody interface{}) (*http.Response, error) {
 	var endpoint string
 	if transport.options.DisableCDN {
 		endpoint = fmt.Sprintf("/download_config_specs?sinceTime=%d", sinceTime)
@@ -72,11 +71,11 @@ func (transport *transport) download_config_specs(sinceTime int64, responseBody 
 	return transport.get(endpoint, responseBody, RequestOptions{})
 }
 
-func (transport *transport) get_id_lists(responseBody interface{}) (*http.Response, error) {
+func (transport *transport) getIdLists(responseBody interface{}) (*http.Response, error) {
 	return transport.post("/get_id_lists", nil, responseBody, RequestOptions{})
 }
 
-func (transport *transport) get_id_list(url string, headers map[string]string) (*http.Response, error) {
+func (transport *transport) getIdList(url string, headers map[string]string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -143,8 +142,8 @@ func (transport *transport) doRequest(
 	if request == nil || err != nil {
 		return nil, err
 	}
-	options.fill_defaults()
-	return retry(options.retries, time.Duration(options.backoff), func() (*http.Response, bool, error) {
+	options.fillDefaults()
+	return retry(options.retries, options.backoff, func() (*http.Response, bool, error) {
 		response, err := transport.client.Do(request)
 		if err != nil {
 			return response, response != nil, err
@@ -152,7 +151,7 @@ func (transport *transport) doRequest(
 		drainAndCloseBody := func() {
 			if response.Body != nil {
 				// Drain body to re-use the same connection
-				_, _ = io.Copy(ioutil.Discard, response.Body)
+				_, _ = io.Copy(io.Discard, response.Body)
 				response.Body.Close()
 			}
 		}

--- a/types.go
+++ b/types.go
@@ -4,7 +4,7 @@ package statsig
 //
 // NOTE: UserID is **required** - see https://docs.statsig.com/messages/serverRequiredUserID\
 // PrivateAttributes are only used for user targeting/grouping in feature gates, dynamic configs,
-// experiments and etc; they are omitted in logs.
+// experiments, etc.; they are omitted in logs.
 type User struct {
 	UserID             string                 `json:"userID"`
 	Email              string                 `json:"email"`
@@ -19,7 +19,7 @@ type User struct {
 	CustomIDs          map[string]string      `json:"customIDs"`
 }
 
-// an event to be sent to Statsig for logging and analysis
+// Event is an event to be sent to Statsig for logging and analysis
 type Event struct {
 	EventName string            `json:"eventName"`
 	User      User              `json:"user"`
@@ -45,7 +45,7 @@ type FeatureGate struct {
 	LogExposure *func(configBase, string)
 }
 
-// A json blob configured in the Statsig Console
+// DynamicConfig is a json blob configured in the Statsig Console
 type DynamicConfig struct {
 	configBase
 }
@@ -93,7 +93,7 @@ func NewLayer(name string, value map[string]interface{}, ruleID string, groupNam
 	}
 }
 
-// Gets the string value at the given key in the DynamicConfig
+// GetString gets the string value at the given key in the DynamicConfig
 // Returns the fallback string if the item at the given key is not found or not of type string
 func (d *configBase) GetString(key string, fallback string) string {
 	if v, ok := d.Value[key]; ok {
@@ -107,7 +107,7 @@ func (d *configBase) GetString(key string, fallback string) string {
 	return fallback
 }
 
-// Gets the float64 value at the given key in the DynamicConfig
+// GetNumber gets the float64 value at the given key in the DynamicConfig
 // Returns the fallback float64 if the item at the given key is not found or not of type float64
 func (d *configBase) GetNumber(key string, fallback float64) float64 {
 	if v, ok := d.Value[key]; ok {
@@ -120,7 +120,7 @@ func (d *configBase) GetNumber(key string, fallback float64) float64 {
 	return fallback
 }
 
-// Gets the boolean value at the given key in the DynamicConfig
+// GetBool gets the boolean value at the given key in the DynamicConfig
 // Returns the fallback boolean if the item at the given key is not found or not of type boolean
 func (d *configBase) GetBool(key string, fallback bool) bool {
 	if v, ok := d.Value[key]; ok {
@@ -133,7 +133,7 @@ func (d *configBase) GetBool(key string, fallback bool) bool {
 	return fallback
 }
 
-// Gets the slice value at the given key in the DynamicConfig
+// GetSlice gets the slice value at the given key in the DynamicConfig
 // Returns the fallback slice if the item at the given key is not found or not of type slice
 func (d *configBase) GetSlice(key string, fallback []interface{}) []interface{} {
 	if v, ok := d.Value[key]; ok {

--- a/user_persistent_storage_example.go
+++ b/user_persistent_storage_example.go
@@ -23,10 +23,10 @@ func (d *userPersistentStorageExample) Save(key string, value string) {
 
 type brokenUserPersistentStorageExample struct{}
 
-func (d *brokenUserPersistentStorageExample) Load(key string) (string, bool) {
+func (d *brokenUserPersistentStorageExample) Load(string) (string, bool) {
 	panic(errors.New("invalid Load function"))
 }
 
-func (d *brokenUserPersistentStorageExample) Save(key string, value string) {
+func (d *brokenUserPersistentStorageExample) Save(string, string) {
 	panic(errors.New("invalid Save function"))
 }

--- a/user_persistent_storage_interface.go
+++ b/user_persistent_storage_interface.go
@@ -1,16 +1,10 @@
 package statsig
 
-/**
- * A storage adapter for persisted values. Can be used for sticky bucketing users in experiments.
- */
+// IUserPersistentStorage is a storage adapter for persisted values. Can be used for sticky bucketing users in experiments.
 type IUserPersistentStorage interface {
-	/**
-	 * Returns the data stored for a specific key
-	 */
+	// Load returns the data stored for a specific key
 	Load(key string) (string, bool)
 
-	/**
-	 * Updates data stored for a specific key
-	 */
+	// Save updates data stored for a specific key
 	Save(key string, data string)
 }

--- a/user_persistent_storage_test.go
+++ b/user_persistent_storage_test.go
@@ -12,7 +12,7 @@ func TestUserPersistentStorage(t *testing.T) {
 	bytes, _ := os.ReadFile("download_config_specs_sticky_experiments.json")
 	opts := &Options{
 		OutputLoggerOptions:   getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions:  getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions:  getStatsigLoggerOptionsForTest(),
 		BootstrapValues:       string(bytes),
 		UserPersistentStorage: persistentStorage,
 	}
@@ -202,7 +202,7 @@ func TestInvalidUserPersistentStorage(t *testing.T) {
 	bytes, _ := os.ReadFile("download_config_specs_sticky_experiments.json")
 	opts := &Options{
 		OutputLoggerOptions:   getOutputLoggerOptionsForTest(t),
-		StatsigLoggerOptions:  getStatsigLoggerOptionsForTest(t),
+		StatsigLoggerOptions:  getStatsigLoggerOptionsForTest(),
 		BootstrapValues:       string(bytes),
 		UserPersistentStorage: persistentStorage,
 	}

--- a/util.go
+++ b/util.go
@@ -52,7 +52,7 @@ func safeGetFirst(slice []string) string {
 	return ""
 }
 
-func safeParseJSONint64(val interface{}) int64 {
+func safeParseJSONInt64(val interface{}) int64 {
 	if num, ok := val.(json.Number); ok {
 		i64, _ := strconv.ParseInt(string(num), 10, 64)
 		return i64


### PR DESCRIPTION
This PR introduces minor code style changes: 
- improving comments for public methods to follow Go code style 
- changing snake case to camel case, preferable in Go
- remove unused func parameters
- improve constants naming and grouping
- replace empty slice declaration `events := []Event{}` with nil slice declaration `var events []Event`
- improve error strings, which should not be capitalised or end with punctuation mark
- fixing some minor typos in README and comments