### PR TITLE
Add Transport Option to allow egress proxies

### DIFF
--- a/statsig.go
+++ b/statsig.go
@@ -25,8 +25,9 @@ func Initialize(sdkKey string) {
 type Options struct {
 	API                   string       `json:"api"`
 	APIOverrides          APIOverrides `json:"api_overrides"`
-	Environment           Environment  `json:"environment"`
-	LocalMode             bool         `json:"localMode"`
+	Transport             http.RoundTripper
+	Environment           Environment `json:"environment"`
+	LocalMode             bool        `json:"localMode"`
 	ConfigSyncInterval    time.Duration
 	IDListSyncInterval    time.Duration
 	LoggingInterval       time.Duration

--- a/transport.go
+++ b/transport.go
@@ -62,8 +62,11 @@ func newTransport(secret string, options *Options) *transport {
 		api:      api,
 		metadata: getStatsigMetadata(),
 		sdkKey:   secret,
-		client:   &http.Client{Timeout: time.Second * 3},
-		options:  options,
+		client: &http.Client{
+			Timeout:   time.Second * 3,
+			Transport: options.Transport,
+		},
+		options: options,
 	}
 }
 


### PR DESCRIPTION
This commit adds a `Transport` to the `Options` struct when constructing a new instance of the Go SDK. If set it allows the end user to pass in their own `http.RoundTripper` instead of using `http.DefaultTransport`.

The reasoning for this change it to allow users to provide a transport which is capabile of acting as middleware for the outbound requests made by the SDK (such as allowing routing via an authenticated egress proxy).