### PR TITLE
Fix incorrect documentation for Override* methods

### DIFF
--- a/client.go
+++ b/client.go
@@ -251,17 +251,17 @@ func (c *Client) LogEvent(event Event) {
 	})
 }
 
-// Override the value of a Feature Gate for the given user
+// Override the value of a Feature Gate for all users
 func (c *Client) OverrideGate(gate string, val bool) {
 	c.errorBoundary.captureVoid(func() { c.evaluator.OverrideGate(gate, val) })
 }
 
-// Override the DynamicConfig value for the given user
+// Override the DynamicConfig value for all users
 func (c *Client) OverrideConfig(config string, val map[string]interface{}) {
 	c.errorBoundary.captureVoid(func() { c.evaluator.OverrideConfig(config, val) })
 }
 
-// Override the Layer value for the given user
+// Override the Layer value for all users
 func (c *Client) OverrideLayer(layer string, val map[string]interface{}) {
 	c.errorBoundary.captureVoid(func() { c.evaluator.OverrideLayer(layer, val) })
 }

--- a/evaluator.go
+++ b/evaluator.go
@@ -304,21 +304,21 @@ func (e *evaluator) getLayerOverrideEval(name string) (*evalResult, bool) {
 	return &evalResult{}, false
 }
 
-// Override the value of a Feature Gate for the given user
+// Override the value of a Feature Gate for all users
 func (e *evaluator) OverrideGate(gate string, val bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.gateOverrides[gate] = val
 }
 
-// Override the DynamicConfig value for the given user
+// Override the DynamicConfig value for all users
 func (e *evaluator) OverrideConfig(config string, val map[string]interface{}) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.configOverrides[config] = val
 }
 
-// Override the Layer value for the given user
+// Override the Layer value for all users
 func (e *evaluator) OverrideLayer(layer string, val map[string]interface{}) {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/statsig.go
+++ b/statsig.go
@@ -182,7 +182,7 @@ func ManuallyLogConfigExposure(user User, config string) {
 	instance.ManuallyLogConfigExposure(user, config)
 }
 
-// Override the value of a Feature Gate for the given user
+// Override the value of a Feature Gate for all users
 func OverrideGate(gate string, val bool) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling OverrideGate"))
@@ -190,7 +190,7 @@ func OverrideGate(gate string, val bool) {
 	instance.OverrideGate(gate, val)
 }
 
-// Override the DynamicConfig value for the given user
+// Override the DynamicConfig value for all users
 func OverrideConfig(config string, val map[string]interface{}) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling OverrideConfig"))
@@ -198,7 +198,7 @@ func OverrideConfig(config string, val map[string]interface{}) {
 	instance.OverrideConfig(config, val)
 }
 
-// Override the Layer value for the given user
+// Override the Layer value for all users
 func OverrideLayer(layer string, val map[string]interface{}) {
 	if !IsInitialized() {
 		panic(fmt.Errorf("must Initialize() statsig before calling OverrideLayer"))


### PR DESCRIPTION
The `OverrideGate`, `OverrideConfig`, and `OverrideLayer` does not override for a specific / given user.

This is confusing to see in the method docs, so changing this to something else.